### PR TITLE
Add readside id to example read side service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 .venv/
 .vscode/
 .local/
+.idea/

--- a/code/read_handler_impl/service.py
+++ b/code/read_handler_impl/service.py
@@ -15,5 +15,5 @@ class ReadSideHandlerImpl(ReadSideHandlerServiceServicer):
 
     def HandleReadSide(self, request, context):
         state = unpack_any(request.state, BankAccount)
-        logger.info(f"entity={request.meta.entity_id}, revision={request.meta.revision_number}, balance={state.account_balance}, eventType={request.event.type_url}")
+        logger.info(f"readSideId={request.read_side_id}, entity={request.meta.entity_id}, revision={request.meta.revision_number}, balance={state.account_balance}, eventType={request.event.type_url}")
         return HandleReadSideResponse(successful=True)

--- a/readme.md
+++ b/readme.md
@@ -27,7 +27,7 @@ git submodule update --init
 brew install earthly
 
 # updates submodules, generates protobufs
-earth +all
+earthly +all
 
 # starts all containers
 docker-compose up -d
@@ -38,7 +38,7 @@ docker-compose exec test-client python -m test_client
 # OTHER HELPFUL COMMANDS
 
 # only generate protobufs locally
-earth +protogen
+earthly +protogen
 
 # supervise app logs
 docker-compose logs -f --tail="all" api write-handler read-handler


### PR DESCRIPTION
As part of https://github.com/namely/chief-of-state/issues/198 we now have the readside id available in the reply.
Now printing the value in the example readside service.

(pending merge of change in service -https://github.com/namely/chief-of-state/pull/325)